### PR TITLE
Bufferization for pipes

### DIFF
--- a/proxysocket.js
+++ b/proxysocket.js
@@ -34,7 +34,7 @@ function proxysocket(socksHost, socksPort, socket) {
 	// While the socket is still being setup the encoding
 	// is saved as we expect binray encoding on the socket
 	// until then
-	var socketEncoding = 'utf8';
+	var socketEncoding = null;
 
 	// Default host/ports to use if not given
 	self.socksHost = socksHost = socksHost || 'localhost';
@@ -56,16 +56,8 @@ function proxysocket(socksHost, socksPort, socket) {
 	// Read event for the real socket
 	socket.on('data', function (buffer) {
 		if (connected) {
-			if (typeof buffer === 'string') {
-				buffer = new Buffer(buffer, 'binary');
-			}
-
 			self.emit('data', buffer);
 		} else {
-			if (typeof buffer === 'string') {
-				buffer = new Buffer(buffer, 'binary');
-			}
-
 			// Emit an event useful for debugging the raw SOCKS data
 			self.emit('socksdata', buffer);
 
@@ -210,7 +202,7 @@ function proxysocket(socksHost, socksPort, socket) {
 
 		// Set the real encoding which could have been
 		// changed while the socket was connecting
-		socket.setEncoding(socketEncoding);
+		setEncoding(socketEncoding);
 
 		if (unsent.length) {
 			for (var i=0; i < unsent.length; i++) {
@@ -349,7 +341,7 @@ function proxysocket(socksHost, socksPort, socket) {
 			self.on('connect', f);
 		}
 
-		socket.setEncoding('binary');
+		setEncoding(null);
 
 		socket.connect(socksPort, socksHost, function () {
 			connecting = false;
@@ -390,12 +382,24 @@ function proxysocket(socksHost, socksPort, socket) {
 
 	self.setEncoding = function (encoding) {
 		if (connected) {
-			socket.setEncoding(encoding);
+			setEncoding(encoding);
 		} else {
 			// Save encoding to be set once connected
 			socketEncoding = encoding;
 		}
 	};
+
+	function setEncoding(enc) {
+		if (enc === null) {
+			// Accroding to nodejs documentation, readable.setEncoding(null)
+			// is a way to disable encoding.
+			// However, it's not. So, need to hack into readable structure.
+			socket.decoder = null;
+			socket.encoding = null;
+		} else {
+			socket.setEncoding(enc);
+		}
+	}
 
 	return self;
 }

--- a/proxysocket.js
+++ b/proxysocket.js
@@ -145,7 +145,7 @@ function proxysocket(socksHost, socksPort, socket) {
 			return socket.pipe(dest, opts);
 		}
 
-		unpiped.push(dest);
+		unpiped.push([dest, opts]);
 		return dest;
 	};
 
@@ -222,7 +222,7 @@ function proxysocket(socksHost, socksPort, socket) {
 
 		if (unpiped.length) {
 			for (var i=0; i < unpiped.length; i++) {
-				socket.pipe(unpiped[i]);
+				socket.pipe(unpiped[i][0], unpiped[i][1]);
 			}
 
 			unpiped = [];

--- a/proxysocket.js
+++ b/proxysocket.js
@@ -74,8 +74,8 @@ function proxysocket(socksHost, socksPort, socket) {
 		}
 	});
 
-	socket.on('error', function () {
-		self.emit('error');
+	socket.on('error', function (e) {
+		self.emit('error', e);
 	});
 
 	socket.on('end', function () {


### PR DESCRIPTION
After previous pull request #5  related to issue #4 socks data still goes to pipe, this is unwanted behavior.
This pull request fixes such behavior by adding bufferization in [proxysocket.write](https://github.com/krisives/proxysocket/blob/3e59b11292aa33418490b2a586d45429e5f79a28/proxysocket.js#L345-L352) manner.