### PR TITLE
return the socket so it can be manipulated after connection

### DIFF
--- a/proxysocket.js
+++ b/proxysocket.js
@@ -352,7 +352,7 @@ function proxysocket(socksHost, socksPort, socket) {
 
 		setEncoding(null);
 
-		socket.connect(socksPort, socksHost, function () {
+		return socket.connect(socksPort, socksHost, function () {
 			connecting = false;
 			sendAuth();
 		});


### PR DESCRIPTION
in proxysocket.connect() function, return the socket so it can be manipulated after connection